### PR TITLE
Override version of google-cloud-secretmanager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,13 @@
       <artifactId>reactor-core</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-secretmanager</artifactId>
+      <version>2.0.2</version>
+      <scope>compile</scope>
+    </dependency>
+
   </dependencies>
 
   <build>


### PR DESCRIPTION
This bypasses a problem related to initialization of the gcp secret manager client, ref:
https://stackoverflow.com/questions/69155870/how-can-i-work-with-micronaut-3-and-google-secret-manager