### PR TITLE
remove snapshot qualifier

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>no.ssb.maskinporten</groupId>
   <artifactId>maskinporten-guardian</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>0.0.1</version>
   <packaging>${packaging}</packaging>
 
   <parent>


### PR DESCRIPTION
https://statistics-norway.atlassian.net/browse/DAPLA-657

DANGER:

I saw in platform-dev that it deploys "master-*" tagged images directly to staging and prod at the same time, so if the rebuild somehow breaks maskinporten guardian, it will happen in prod immediately.