### PR TITLE
Implement retry mechanism for SocketExceptions

### DIFF
--- a/src/main/java/no/ssb/guardian/RetryListener.java
+++ b/src/main/java/no/ssb/guardian/RetryListener.java
@@ -1,5 +1,6 @@
 package no.ssb.guardian;
 
+import io.micronaut.core.type.MutableArgumentValue;
 import io.micronaut.retry.event.RetryEvent;
 import io.micronaut.retry.event.RetryEventListener;
 import jakarta.inject.Singleton;
@@ -10,8 +11,9 @@ import lombok.extern.slf4j.Slf4j;
 public class RetryListener implements RetryEventListener {
     @Override
     public void onApplicationEvent(RetryEvent event) {
-        log.error("Request failed {} time(s) for {} with error:", event.getRetryState().currentAttempt(),
-                event.getSource().getExecutableMethod().getName(),
+        final MutableArgumentValue<?> request = event.getSource().getParameters().get("request");
+        log.error("Request failed {} time(s) for {}:", event.getRetryState().currentAttempt(),
+                request != null ? request.getValue(): "<empty request>",
                 event.getThrowable());
     }
 

--- a/src/main/java/no/ssb/guardian/RetryListener.java
+++ b/src/main/java/no/ssb/guardian/RetryListener.java
@@ -1,0 +1,22 @@
+package no.ssb.guardian;
+
+import io.micronaut.retry.event.RetryEvent;
+import io.micronaut.retry.event.RetryEventListener;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Singleton
+public class RetryListener implements RetryEventListener {
+    @Override
+    public void onApplicationEvent(RetryEvent event) {
+        log.error("Request failed {} time(s) for {} with error:", event.getRetryState().currentAttempt(),
+                event.getSource().getExecutableMethod().getName(),
+                event.getThrowable());
+    }
+
+    @Override
+    public boolean supports(RetryEvent event) {
+        return true;
+    }
+}

--- a/src/main/java/no/ssb/guardian/maskinporten/MaskinportenAccessTokenController.java
+++ b/src/main/java/no/ssb/guardian/maskinporten/MaskinportenAccessTokenController.java
@@ -183,6 +183,11 @@ public class MaskinportenAccessTokenController {
         return error(request, e, e.getHttpStatus(), e.getMessage());
     }
 
+    @Error
+    public HttpResponse<JsonError> runtimeError(HttpRequest request, RuntimeException e) {
+        metrics.incrementClientError("runtime-exception");
+        return error(request, e, HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+    }
     private static HttpResponse<JsonError> error(HttpRequest request, Exception e, HttpStatus httpStatus, String httpStatusReason) {
         JsonError error = new JsonError(e.getMessage())
           .link(Link.SELF, Link.of(request.getUri()));

--- a/src/main/java/no/ssb/guardian/maskinporten/MaskinportenAccessTokenController.java
+++ b/src/main/java/no/ssb/guardian/maskinporten/MaskinportenAccessTokenController.java
@@ -185,7 +185,7 @@ public class MaskinportenAccessTokenController {
 
     @Error
     public HttpResponse<JsonError> runtimeError(HttpRequest request, RuntimeException e) {
-        metrics.incrementClientError("runtime-exception");
+        metrics.incrementServerError("runtime-exception");
         return error(request, e, HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
     }
     private static HttpResponse<JsonError> error(HttpRequest request, Exception e, HttpStatus httpStatus, String httpStatusReason) {

--- a/src/test/java/no/ssb/guardian/maskinporten/MaskinportenAccessTokenControllerRetryTest.java
+++ b/src/test/java/no/ssb/guardian/maskinporten/MaskinportenAccessTokenControllerRetryTest.java
@@ -1,0 +1,76 @@
+package no.ssb.guardian.maskinporten;
+
+import io.micronaut.http.HttpStatus;
+import io.micronaut.runtime.server.EmbeddedServer;
+import io.micronaut.test.annotation.MockBean;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import jakarta.inject.Inject;
+import no.ssb.guardian.maskinporten.MaskinportenAccessTokenController.FetchMaskinportenAccessTokenRequest;
+import no.ssb.guardian.maskinporten.client.MaskinportenClient;
+import no.ssb.guardian.maskinporten.client.MaskinportenClientRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.SocketException;
+import java.util.Set;
+
+import static io.restassured.RestAssured.*;
+import static no.ssb.guardian.testsupport.KeycloakDevTokenIssuer.*;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
+
+@MicronautTest
+public class MaskinportenAccessTokenControllerRetryTest {
+
+    private final static String MASKINPORTEN_ACCESS_TOKEN_ENDPOINT = "/maskinporten/access-token";
+    private final static String MASKINPORTEN_DUMMY_ACCESS_TOKEN = "maskinporten-dummy-token";
+    private final static String MASKINPORTEN_CLIENT_ID_1 = "7ea43b76-6b7d-49e8-af2b-4114ebb66c80";
+    private final static Set<String> REQUESTED_SCOPES = Set.of("some:scope1");
+
+    @Inject
+    private EmbeddedServer embeddedServer;
+
+    @Inject
+    MaskinportenClientRegistry maskinportenClientRegistry;
+
+    @MockBean(MaskinportenClientRegistry.class)
+    MaskinportenClientRegistry maskinportenklientRegistry() {
+        return mock(MaskinportenClientRegistry.class);
+    }
+
+    private MaskinportenClient maskinportenClientMock = mock(MaskinportenClient.class);
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = embeddedServer.getPort();
+        when(maskinportenClientRegistry.get(any())).thenReturn(maskinportenClientMock);
+    }
+
+    @Test
+    void validRequest_shouldRetryOnConnectionError() {
+        when(maskinportenClientMock.getAccessToken(anyCollection()))
+                .thenThrow(new RuntimeException(new SocketException(("Connection reset"))))
+                .thenReturn(MASKINPORTEN_DUMMY_ACCESS_TOKEN);
+
+        given()
+          .auth().oauth2(personalAccessToken("Kjell", "Fjell"))
+          .contentType(ContentType.JSON)
+        .when()
+          .body(FetchMaskinportenAccessTokenRequest.builder()
+            .maskinportenClientId(MASKINPORTEN_CLIENT_ID_1)
+            .scopes(REQUESTED_SCOPES)
+            .build()
+            )
+            .post(MASKINPORTEN_ACCESS_TOKEN_ENDPOINT)
+        .then()
+          .statusCode(HttpStatus.OK.getCode())
+          .body(
+              "accessToken", equalTo(MASKINPORTEN_DUMMY_ACCESS_TOKEN)
+          );
+        verify(maskinportenClientMock, times(2)).getAccessToken(anyCollection());
+    }
+}

--- a/src/test/java/no/ssb/guardian/maskinporten/MaskinportenAccessTokenControllerRetryTest.java
+++ b/src/test/java/no/ssb/guardian/maskinporten/MaskinportenAccessTokenControllerRetryTest.java
@@ -52,7 +52,7 @@ public class MaskinportenAccessTokenControllerRetryTest {
 
     @Test
     void validRequest_shouldRetryOnConnectionError() {
-        when(maskinportenClientMock.getAccessToken(anyCollection()))
+        when(maskinportenClientMock.getAccessToken(anySet()))
                 .thenThrow(new RuntimeException(new SocketException(("Connection reset"))))
                 .thenReturn(MASKINPORTEN_DUMMY_ACCESS_TOKEN);
 
@@ -71,6 +71,6 @@ public class MaskinportenAccessTokenControllerRetryTest {
           .body(
               "accessToken", equalTo(MASKINPORTEN_DUMMY_ACCESS_TOKEN)
           );
-        verify(maskinportenClientMock, times(2)).getAccessToken(anyCollection());
+        verify(maskinportenClientMock, times(2)).getAccessToken(anySet());
     }
 }

--- a/src/test/java/no/ssb/guardian/maskinporten/MaskinportenAccessTokenControllerTest.java
+++ b/src/test/java/no/ssb/guardian/maskinporten/MaskinportenAccessTokenControllerTest.java
@@ -23,8 +23,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @MicronautTest
 public class MaskinportenAccessTokenControllerTest {
@@ -33,7 +32,6 @@ public class MaskinportenAccessTokenControllerTest {
     private final static String MASKINPORTEN_DUMMY_ACCESS_TOKEN = "maskinporten-dummy-token";
     private final static String MASKINPORTEN_CLIENT_ID_1 = "7ea43b76-6b7d-49e8-af2b-4114ebb66c80";
     private final static String MASKINPORTEN_CLIENT_ID_2 = "675c0111-2035-4d15-9cce-037f55439e80";
-    private final static Set<String> DEFAULT_SCOPES = Set.of("some:scope1", "some:scope2");
     private final static Set<String> REQUESTED_SCOPES = Set.of("some:scope1");
 
     @Inject
@@ -41,6 +39,8 @@ public class MaskinportenAccessTokenControllerTest {
 
     @Inject
     MaskinportenClientRegistry maskinportenClientRegistry;
+    private MaskinportenClient maskinportenClientMock = mock(MaskinportenClient.class);
+
 
     @MockBean(MaskinportenClientRegistry.class)
     MaskinportenClientRegistry maskinportenklientRegistry() {
@@ -50,10 +50,8 @@ public class MaskinportenAccessTokenControllerTest {
     @BeforeEach
     void setUp() {
         RestAssured.port = embeddedServer.getPort();
-
-        MaskinportenClient maskinportenClient = mock(MaskinportenClient.class);
-        when(maskinportenClient.getAccessToken(anyCollection())).thenReturn(MASKINPORTEN_DUMMY_ACCESS_TOKEN);
-        when(maskinportenClientRegistry.get(any())).thenReturn(maskinportenClient);
+        when(maskinportenClientMock.getAccessToken(anyCollection())).thenReturn(MASKINPORTEN_DUMMY_ACCESS_TOKEN);
+        when(maskinportenClientRegistry.get(any())).thenReturn(maskinportenClientMock);
     }
 
     private String serviceAccountKeycloakToken() {
@@ -76,6 +74,7 @@ public class MaskinportenAccessTokenControllerTest {
           .body(
             "accessToken", equalTo(MASKINPORTEN_DUMMY_ACCESS_TOKEN)
           );
+        verify(maskinportenClientMock, times(1)).getAccessToken(anyCollection());
     }
 
     @Test
@@ -91,6 +90,7 @@ public class MaskinportenAccessTokenControllerTest {
           .body(
             "accessToken", equalTo(MASKINPORTEN_DUMMY_ACCESS_TOKEN)
           );
+        verify(maskinportenClientMock, times(1)).getAccessToken(anyCollection());
     }
 
     @Test
@@ -109,6 +109,7 @@ public class MaskinportenAccessTokenControllerTest {
           .body(
             "message", equalTo("maskinportenClientId cannot be explicitly specified for service account users")
           );
+        verifyNoInteractions(maskinportenClientMock);
     }
 
     @Test


### PR DESCRIPTION
Maskinporten Guardian frequently gets SocketExeptions when connecting to Maskinporten. This PR will cope for this by retrying 3 times before the request fails. Note that any other execptions (e.g.. bad/invalid requests) should  `not` trigger a retry.