### PR TITLE
Add memory limit in prod

### DIFF
--- a/.nais/prod/nais.yaml
+++ b/.nais/prod/nais.yaml
@@ -15,6 +15,8 @@ spec:
     requests:
       cpu: 100m
       memory: 500Mi
+    limits:
+        memory: 1Gi
 
   ingresses:
     - https://guardian.intern.ssb.no


### PR DESCRIPTION
The service, when idling with 0 traffic is currently at 70% of the memory limit (which is the same as the requested memory because it is not set). This PR adds a memory limit to match what is available in BIP