### PR TITLE
Removed old labid url as issuer

### DIFF
--- a/.nais/test/nais.yaml
+++ b/.nais/test/nais.yaml
@@ -27,7 +27,6 @@ spec:
         - host: "test.maskinporten.no"
         - host: "test.sky.maskinporten.no"
         - host: "labid.lab.dapla-test-external.ssb.no"
-        - host: "labid.lab.dapla-test.ssb.no"
 
   liveness:
     path: /health/liveness
@@ -99,8 +98,6 @@ data:
                   url: 'https://auth.test.ssb.no/realms/ssb/protocol/openid-connect/certs'
                 lab-id-north1-test:
                   url: 'https://labid.lab.dapla-test-external.ssb.no/jwks'
-                lab-id-west4-test:
-                  url: 'https://labid.lab.dapla-test.ssb.no/jwks'
                   
         intercept-url-map:
           - pattern: /**/openapi/**


### PR DESCRIPTION
To fix error: `09:01:18.855 [default-nioEventLoopGroup-1-8] ERROR i.m.h.client.netty.DefaultHttpClient - Failed to connect to remote                                                                                        │
│ java.net.UnknownHostException: labid.lab.dapla-test.ssb.no: Name or service not known`