### PR TITLE
Add support for access token audience in Maskinporten integration

### DIFF
--- a/.nais/prod/nais.yaml
+++ b/.nais/prod/nais.yaml
@@ -28,7 +28,6 @@ spec:
         - host: "maskinporten.no"
         - host: "sky.maskinporten.no"
         - host: "labid.lab.dapla-external.ssb.no"
-        - host: "labid.lab.dapla.ssb.no"
 
   liveness:
     path: /health/liveness

--- a/src/main/java/no/ssb/guardian/maskinporten/MaskinportenAccessTokenController.java
+++ b/src/main/java/no/ssb/guardian/maskinporten/MaskinportenAccessTokenController.java
@@ -86,7 +86,7 @@ public class MaskinportenAccessTokenController {
                 .principalName(token.getSub())
                 .clientConfig(maskinportenClientConfig)
                 .requestedScopes(requestedScopes(request.getScopes(), maskinportenClientConfig.getDefaultScopes()))
-                .accesssTokenAudience(request.getAccessTokenAudience())
+                .accessTokenAudience(request.getAccessTokenAudience())
                 .build();
     }
 

--- a/src/main/java/no/ssb/guardian/maskinporten/MaskinportenAccessTokenController.java
+++ b/src/main/java/no/ssb/guardian/maskinporten/MaskinportenAccessTokenController.java
@@ -82,11 +82,12 @@ public class MaskinportenAccessTokenController {
         }
 
         return MaskinportenService.GetMaskinportenAccessTokenDto.builder()
-          .userType(token.getUserType())
-          .principalName(token.getSub())
-          .clientConfig(maskinportenClientConfig)
-          .requestedScopes(requestedScopes(request.getScopes(), maskinportenClientConfig.getDefaultScopes()))
-          .build();
+                .userType(token.getUserType())
+                .principalName(token.getSub())
+                .clientConfig(maskinportenClientConfig)
+                .requestedScopes(requestedScopes(request.getScopes(), maskinportenClientConfig.getDefaultScopes()))
+                .accesssTokenAudience(request.getAccessTokenAudience())
+                .build();
     }
 
     @VisibleForTesting
@@ -166,6 +167,7 @@ public class MaskinportenAccessTokenController {
     public static class FetchMaskinportenAccessTokenRequest {
         private String maskinportenClientId;
         private Set<String> scopes;
+        private String accessTokenAudience;
     }
 
     @Data

--- a/src/main/java/no/ssb/guardian/maskinporten/MaskinportenService.java
+++ b/src/main/java/no/ssb/guardian/maskinporten/MaskinportenService.java
@@ -35,7 +35,16 @@ public class MaskinportenService {
         }
 
         MaskinportenClient maskinportenClient = maskinportenClientRegistry.get(dto.getClientConfig());
-        String maskinportenAccessToken = maskinportenClient.getAccessToken(dto.getRequestedScopes());
+
+        String maskinportenAccessToken;
+
+        if (dto.getAccesssTokenAudience() != null && !dto.getAccesssTokenAudience().isEmpty()) {
+            maskinportenAccessToken = maskinportenClient.getAccessToken(dto.getRequestedScopes(), dto.getAccesssTokenAudience());
+
+        } else {
+            maskinportenAccessToken = maskinportenClient.getAccessToken(dto.getRequestedScopes());
+        }
+
         return maskinportenAccessToken;
     }
 
@@ -53,6 +62,8 @@ public class MaskinportenService {
 
         @NonNull
         private Set<String> requestedScopes;
+
+        private String accesssTokenAudience;
     }
 
 }

--- a/src/main/java/no/ssb/guardian/maskinporten/MaskinportenService.java
+++ b/src/main/java/no/ssb/guardian/maskinporten/MaskinportenService.java
@@ -38,8 +38,8 @@ public class MaskinportenService {
 
         String maskinportenAccessToken;
 
-        if (dto.getAccesssTokenAudience() != null && !dto.getAccesssTokenAudience().isEmpty()) {
-            maskinportenAccessToken = maskinportenClient.getAccessToken(dto.getRequestedScopes(), dto.getAccesssTokenAudience());
+        if (dto.getAccessTokenAudience() != null && !dto.getAccessTokenAudience().isEmpty()) {
+            maskinportenAccessToken = maskinportenClient.getAccessToken(dto.getRequestedScopes(), dto.getAccessTokenAudience());
 
         } else {
             maskinportenAccessToken = maskinportenClient.getAccessToken(dto.getRequestedScopes());
@@ -63,7 +63,8 @@ public class MaskinportenService {
         @NonNull
         private Set<String> requestedScopes;
 
-        private String accesssTokenAudience;
+        private String accessTokenAudience;
     }
 
 }
+

--- a/src/main/java/no/ssb/guardian/maskinporten/client/MaskinportenClient.java
+++ b/src/main/java/no/ssb/guardian/maskinporten/client/MaskinportenClient.java
@@ -9,4 +9,9 @@ public interface MaskinportenClient {
      */
     String getAccessToken(Set<String> scopes);
 
+    /**
+     * Retrieve maskinporten access token with specifiecd scope and access token audience
+     *
+     */
+    String getAccessToken(Set<String> scopes, String accessTokenAudience);
 }

--- a/src/main/java/no/ssb/guardian/maskinporten/client/MaskinportenClient.java
+++ b/src/main/java/no/ssb/guardian/maskinporten/client/MaskinportenClient.java
@@ -10,7 +10,10 @@ public interface MaskinportenClient {
     String getAccessToken(Set<String> scopes);
 
     /**
-     * Retrieve maskinporten access token with specifiecd scope and access token audience
+     * Retrieve maskinporten access token with specified scope and access token audience
+     * @param scopes the set of scopes to request in the access token
+     * @param accessTokenAudience the audience to request in the access token
+     * @return access token that can be used to access APIs protected by maskinporten
      *
      */
     String getAccessToken(Set<String> scopes, String accessTokenAudience);

--- a/src/main/java/no/ssb/guardian/maskinporten/client/MaskinportenClient.java
+++ b/src/main/java/no/ssb/guardian/maskinporten/client/MaskinportenClient.java
@@ -10,7 +10,7 @@ public interface MaskinportenClient {
     String getAccessToken(Set<String> scopes);
 
     /**
-     * Retrieve maskinporten access token with specified scope and access token audience
+     * Retrieve maskinporten access token with specified scopes and access token audience
      * @param scopes the set of scopes to request in the access token
      * @param accessTokenAudience the audience to request in the access token
      * @return access token that can be used to access APIs protected by maskinporten

--- a/src/main/java/no/ssb/guardian/maskinporten/client/MaskinportenClientImpl.java
+++ b/src/main/java/no/ssb/guardian/maskinporten/client/MaskinportenClientImpl.java
@@ -21,4 +21,18 @@ public class MaskinportenClientImpl implements MaskinportenClient {
         return maskinportenklient.getAccessToken(request);
     }
 
+     /**
+     * Retrieve maskinporten access token with specified scopes and access token audience
+     * @param scopes
+     * @param accessTokenAudience
+     * @return access token that can be used to access APIs protected by maskinporten
+     */
+    public String getAccessToken(@NonNull Set<String> scopes, String accessTokenAudience) {
+        AccessTokenRequest request = AccessTokenRequest.builder()
+                .scopes(scopes)
+                .audience(accessTokenAudience)
+                .build();
+        return maskinportenklient.getAccessToken(request);
+    }
+
 }

--- a/src/test/java/no/ssb/guardian/maskinporten/MaskinportenAccessTokenControllerRetryTest.java
+++ b/src/test/java/no/ssb/guardian/maskinporten/MaskinportenAccessTokenControllerRetryTest.java
@@ -30,6 +30,7 @@ public class MaskinportenAccessTokenControllerRetryTest {
     private final static String MASKINPORTEN_DUMMY_ACCESS_TOKEN = "maskinporten-dummy-token";
     private final static String MASKINPORTEN_CLIENT_ID_1 = "7ea43b76-6b7d-49e8-af2b-4114ebb66c80";
     private final static Set<String> REQUESTED_SCOPES = Set.of("some:scope1");
+    private final static String ACCESS_TOKEN_AUDIENCE = "dummy-audience";
 
     @Inject
     private EmbeddedServer embeddedServer;
@@ -59,17 +60,17 @@ public class MaskinportenAccessTokenControllerRetryTest {
           .auth().oauth2(personalAccessToken("kje"))
           .contentType(ContentType.JSON)
         .when()
-          .body(FetchMaskinportenAccessTokenRequest.builder()
-            .maskinportenClientId(MASKINPORTEN_CLIENT_ID_1)
-            .scopes(REQUESTED_SCOPES)
-            .build()
-            )
-            .post(MASKINPORTEN_ACCESS_TOKEN_ENDPOINT)
-        .then()
-          .statusCode(HttpStatus.OK.getCode())
-          .body(
-              "accessToken", equalTo(MASKINPORTEN_DUMMY_ACCESS_TOKEN)
-          );
+                .body(FetchMaskinportenAccessTokenRequest.builder()
+                                .maskinportenClientId(MASKINPORTEN_CLIENT_ID_1)
+                                .scopes(REQUESTED_SCOPES)
+                        .build()
+                )
+                .post(MASKINPORTEN_ACCESS_TOKEN_ENDPOINT)
+                .then()
+                .statusCode(HttpStatus.OK.getCode())
+                .body(
+                        "accessToken", equalTo(MASKINPORTEN_DUMMY_ACCESS_TOKEN)
+                );
         verify(maskinportenClientMock, times(2)).getAccessToken(anySet());
     }
 }

--- a/src/test/java/no/ssb/guardian/maskinporten/MaskinportenAccessTokenControllerTest.java
+++ b/src/test/java/no/ssb/guardian/maskinporten/MaskinportenAccessTokenControllerTest.java
@@ -33,6 +33,7 @@ public class MaskinportenAccessTokenControllerTest {
     private final static String MASKINPORTEN_CLIENT_ID_1 = "7ea43b76-6b7d-49e8-af2b-4114ebb66c80";
     private final static String MASKINPORTEN_CLIENT_ID_2 = "675c0111-2035-4d15-9cce-037f55439e80";
     private final static Set<String> REQUESTED_SCOPES = Set.of("some:scope1");
+    private final static String ACCESS_TOKEN_AUDIENCE = "dummy_access_token_audience";
 
     @Inject
     private EmbeddedServer embeddedServer;
@@ -78,6 +79,25 @@ public class MaskinportenAccessTokenControllerTest {
         verify(maskinportenClientMock, times(1)).getAccessToken(anySet());
     }
 
+    @Test
+    void validServiceAccount_getAccessToken_with_audience_shouldReturnToken() {
+        given()
+                .auth().oauth2(serviceAccountKeycloakToken())
+                .contentType(ContentType.JSON)
+                .when()
+                .body(FetchMaskinportenAccessTokenRequest.builder()
+                        .scopes(REQUESTED_SCOPES)
+                        .accessTokenAudience(ACCESS_TOKEN_AUDIENCE)
+                        .build()
+                )
+                .post(MASKINPORTEN_ACCESS_TOKEN_ENDPOINT)
+                .then()
+                .statusCode(HttpStatus.OK.getCode())
+                .body(
+                        "accessToken", equalTo(MASKINPORTEN_DUMMY_ACCESS_TOKEN)
+                );
+        verify(maskinportenClientMock, times(1)).getAccessToken(anySet(), any());
+    }
     @Test
     void serviceAccount_getAccessTokenWithEmptyRequestBody_shouldReturnToken() {
         given()

--- a/src/test/java/no/ssb/guardian/maskinporten/MaskinportenAccessTokenControllerTest.java
+++ b/src/test/java/no/ssb/guardian/maskinporten/MaskinportenAccessTokenControllerTest.java
@@ -51,6 +51,7 @@ public class MaskinportenAccessTokenControllerTest {
     void setUp() {
         RestAssured.port = embeddedServer.getPort();
         when(maskinportenClientMock.getAccessToken(anySet())).thenReturn(MASKINPORTEN_DUMMY_ACCESS_TOKEN);
+        when(maskinportenClientMock.getAccessToken(anySet(), any())).thenReturn(MASKINPORTEN_DUMMY_ACCESS_TOKEN);
         when(maskinportenClientRegistry.get(any())).thenReturn(maskinportenClientMock);
     }
 


### PR DESCRIPTION
This pull request adds support for specifying an audience when requesting a Maskinporten access token. The changes update the service, controller, client interface, and implementation to handle an optional `accessTokenAudience` parameter, and also update the tests to cover this new functionality.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/maskinporten-guardian/106)
<!-- Reviewable:end -->
